### PR TITLE
Updated template.yaml changed npm ci to npm install

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -203,7 +203,7 @@ Resources:
             preBuild:
               commands:
                 - cd client
-                - npm ci
+                - npm install
             build:
               commands:
                 - npm run build


### PR DESCRIPTION
cipm requires an existing package-lock.json file which using npm ci does not provide. Changing to use npm install resolves the issue.